### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@ apply plugin: 'war'
 
 war {    
     //set archive name for consistency 
-    archiveName='cics-java-liberty-restapp.war'
+    // Gradle 8.10 syntax
+    archiveName.set 'cics-java-liberty-restapp.war'
+    // Gradle ?? syntax
+    // archiveName='cics-java-liberty-restapp.war'
 }
 
 // If in Eclipse, add Javadoc to the local project classpath


### PR DESCRIPTION
The original syntax did not work for me with gradle 8.10.

```
* Where:
Build file '/Users/davis/progs/hbjava/src/proj9/build.gradle' line: 18

* What went wrong:
A problem occurred evaluating root project 'proj9'.
> Could not find method archiveFileName() for arguments [cics-java-liberty-restapp.war] on task ':war' of type org.gradle.api.tasks.bundling.War.
```