### PR TITLE
fix: remove setup-gradle from build-gradlew job and rename workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - id: copyright-action
         uses: cicsdev/.github/.github/actions/samples-copyright-checker@4134522d8109169bb8c460db841f94167ec2802f
         with:
-          directory: './cics-java-liberty-restapp/'
+          directory: './cics-java-liberty-restapp-app/'
           file-extensions: '*.java'
           base-copyright: 'Copyright IBM Corp. 2026'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           directory: './cics-java-liberty-restapp/'
           file-extensions: '*.java'
-          base-copyright: 'Copyright IBM Corp. 2025'
+          base-copyright: 'Copyright IBM Corp. 2026'
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build-maven:
@@ -98,7 +98,5 @@ jobs:
       with:
         java-version: ${{ matrix.jdk }}
         distribution: 'semeru'
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-    - name: Build with Gradle
+    - name: Build with Gradle Wrapper
       run: ./gradlew build -Pjava_version=${{ matrix.jdk }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cics-java-liberty-restapp
 ===========================
 
-[![Build](https://github.com/cicsdev/cics-java-liberty-restapp/actions/workflows/main.yml/badge.svg)](https://github.com/cicsdev/cics-java-liberty-restapp/actions/workflows/main.yml)
+[![Build](https://github.com/cicsdev/cics-java-liberty-restapp/actions/workflows/build.yaml/badge.svg)](https://github.com/cicsdev/cics-java-liberty-restapp/actions/workflows/build.yaml)
 
 Sample RESTful web application for deployment to a Liberty JVM server in CICS. The application is supplied with two resources:
 


### PR DESCRIPTION
- Renamed .github/workflows/main.yml to build.yaml
- Removed setup-gradle action from build-gradlew job (lines 101-102)
- Wrapper jobs should only use setup-java to validate standalone functionality
- Updated copyright year to 2026
- Aligns with workflow naming standards across CICS sample repositories
- Fixes build failures in Gradle wrapper tests
- Ensure README build badge references the correct (build.yaml) workflow